### PR TITLE
Remove Unnecessary Repetition in CLI Help

### DIFF
--- a/src/pattern_seek/cli.py
+++ b/src/pattern_seek/cli.py
@@ -55,18 +55,6 @@ def main(
     
     PATHS: One or more files or directories to search.
     Wildcards are supported, e.g., *.txt
-    
-    Args:
-        paths: List of file paths or directories to search
-        pattern: List of pattern types to search for
-        text: Text pattern to search for when using the "text" pattern type
-        case_sensitive: Whether text search should be case-sensitive
-        whole_word: Whether to match whole words only for text search
-        context: Number of context lines to include before and after matches
-        no_color: Whether to disable colored output
-        
-    Returns:
-        None
     """
     
      # Determine which patterns to search for


### PR DESCRIPTION
Change verbose/repetitive help to something more concise.

Go from:
![image](https://github.com/user-attachments/assets/55b14f58-e70c-4285-95d4-664b7d28dbd0)

To:
<img width="551" alt="image" src="https://github.com/user-attachments/assets/c7f99307-be4e-41f4-b8d0-2a3be7d86f7f" />
